### PR TITLE
route websocket proxy traffics to different destinations

### DIFF
--- a/peripherals/eos-evm-ws-proxy/block-monitor.js
+++ b/peripherals/eos-evm-ws-proxy/block-monitor.js
@@ -130,11 +130,7 @@ class BlockMonitor extends EventEmitter {
         }
       }
 
-      while(this.reversible_blocks.length > 1024) { // protection of memory grow in case leap rpc not working
-        this.remove_front_block();
-      }
-
-      if( found_next_block == true && this.reversible_blocks.length > 180 + 30) { // reduce frequency of calling get_evm_lib
+      if( found_next_block == true && this.reversible_blocks.length > 180 + 6) { // reduce frequency of calling get_evm_lib
         const evm_lib = await this.get_evm_lib();
         // keep at least 180 blocks in case evm-node is out of sync with leap
         while(this.reversible_blocks.length > 180 && this.reversible_blocks.peek().number < evm_lib) {

--- a/peripherals/eos-evm-ws-proxy/config.js
+++ b/peripherals/eos-evm-ws-proxy/config.js
@@ -1,9 +1,11 @@
 require('dotenv').config();
 const ws_listening_port = parseInt(process.env.WS_LISTENING_PORT, 10) || 3333;
 const ws_listening_host = process.env.WS_LISTENING_HOST || "localhost";
-const web3_rpc_endpoint = process.env.WEB3_RPC_ENDPOINT || "http://localhost:5000/";
+const web3_rpc_endpoint = process.env.WEB3_RPC_ENDPOINT || "http://127.0.0.1:8881/";
+const web3_rpc_test_endpoint = process.env.WEB3_RPC_TEST_ENDPOINT || "http://127.0.0.1:8882/";
 const nodeos_rpc_endpoint = process.env.NODEOS_RPC_ENDPOINT || "http://127.0.0.1:8888/";
 const miner_rpc_endpoint = process.env.MINER_RPC_ENDPOINT || "http://127.0.0.1:18888/";
+const whitelist_methods = process.env.WHITELIST_METHODS || "net_version,eth_blockNumber,eth_chainId,eth_protocolVersion,eth_getBlockByHash,eth_getBlockByNumber,eth_getBlockTransactionCountByHash,eth_getBlockTransactionCountByNumber,eth_getUncleByBlockHashAndIndex,eth_getUncleByBlockNumberAndIndex,eth_getUncleCountByBlockHash,eth_getUncleCountByBlockNumber,eth_getTransactionByHash,eth_getRawTransactionByHash,eth_getTransactionByBlockHashAndIndex,eth_getRawTransactionByBlockHashAndIndex,eth_getTransactionByBlockNumberAndIndex,eth_getRawTransactionByBlockNumberAndIndex,eth_getTransactionReceipt,eth_getBlockReceipts,eth_estimateGas,eth_getBalance,eth_getCode,eth_getTransactionCount,eth_getStorageAt,eth_call,eth_callBundle,eth_createAccessList";
 const poll_interval = parseInt(process.env.POLL_INTERVAL, 10) || 1000;
 const max_logs_subs_per_connection = parseInt(process.env.MAX_LOGS_SUBS_PER_CONNECTION, 10) || 1;
 const max_minedtx_subs_per_connection = parseInt(process.env.MAX_MINEDTX_SUBS_PER_CONNECTION, 10) || 1;
@@ -13,10 +15,12 @@ module.exports = {
   ws_listening_port,
   ws_listening_host,
   web3_rpc_endpoint,
+  web3_rpc_test_endpoint,
   nodeos_rpc_endpoint,
   miner_rpc_endpoint,
   poll_interval,
   max_logs_subs_per_connection,
   max_minedtx_subs_per_connection,
-  log_level
+  log_level,
+  whitelist_methods
 };

--- a/peripherals/eos-evm-ws-proxy/config.js
+++ b/peripherals/eos-evm-ws-proxy/config.js
@@ -3,6 +3,7 @@ const ws_listening_port = parseInt(process.env.WS_LISTENING_PORT, 10) || 3333;
 const ws_listening_host = process.env.WS_LISTENING_HOST || "localhost";
 const web3_rpc_endpoint = process.env.WEB3_RPC_ENDPOINT || "http://localhost:5000/";
 const nodeos_rpc_endpoint = process.env.NODEOS_RPC_ENDPOINT || "http://127.0.0.1:8888/";
+const miner_rpc_endpoint = process.env.MINER_RPC_ENDPOINT || "http://127.0.0.1:18888/";
 const poll_interval = parseInt(process.env.POLL_INTERVAL, 10) || 1000;
 const max_logs_subs_per_connection = parseInt(process.env.MAX_LOGS_SUBS_PER_CONNECTION, 10) || 1;
 const max_minedtx_subs_per_connection = parseInt(process.env.MAX_MINEDTX_SUBS_PER_CONNECTION, 10) || 1;
@@ -13,6 +14,7 @@ module.exports = {
   ws_listening_host,
   web3_rpc_endpoint,
   nodeos_rpc_endpoint,
+  miner_rpc_endpoint,
   poll_interval,
   max_logs_subs_per_connection,
   max_minedtx_subs_per_connection,

--- a/peripherals/eos-evm-ws-proxy/subscription-server.js
+++ b/peripherals/eos-evm-ws-proxy/subscription-server.js
@@ -6,11 +6,11 @@ const {bigint_replacer} = require('./utils');
 
 class SubscriptionServer extends EventEmitter {
 
-  constructor({web3_rpc_endpoint, nodeos_rpc_endpoint, miner_rpc_endpoint, ws_listening_host, ws_listening_port, poll_interval, max_logs_subs_per_connection, max_minedtx_subs_per_connection, logger}) {
+  constructor({web3_rpc_endpoint, web3_rpc_test_endpoint, nodeos_rpc_endpoint, miner_rpc_endpoint, ws_listening_host, ws_listening_port, poll_interval, max_logs_subs_per_connection, max_minedtx_subs_per_connection, logger, whitelist_methods}) {
     super();
 
     this.block_monitor = new BlockMonitor({web3_rpc_endpoint, nodeos_rpc_endpoint, poll_interval, logger});
-    this.web_socket_handler = new WebSocketHandler({ws_listening_host, ws_listening_port, web3_rpc_endpoint, miner_rpc_endpoint, logger});
+    this.web_socket_handler = new WebSocketHandler({ws_listening_host, ws_listening_port, web3_rpc_endpoint, web3_rpc_test_endpoint, miner_rpc_endpoint, logger, whitelist_methods});
     this.max_logs_subs_per_connection = max_logs_subs_per_connection;
     this.max_minedtx_subs_per_connection = max_minedtx_subs_per_connection;
     this.web3 = new Web3(web3_rpc_endpoint);

--- a/peripherals/eos-evm-ws-proxy/subscription-server.js
+++ b/peripherals/eos-evm-ws-proxy/subscription-server.js
@@ -6,11 +6,11 @@ const {bigint_replacer} = require('./utils');
 
 class SubscriptionServer extends EventEmitter {
 
-  constructor({web3_rpc_endpoint, nodeos_rpc_endpoint, ws_listening_host, ws_listening_port, poll_interval, max_logs_subs_per_connection, max_minedtx_subs_per_connection, logger}) {
+  constructor({web3_rpc_endpoint, nodeos_rpc_endpoint, miner_rpc_endpoint, ws_listening_host, ws_listening_port, poll_interval, max_logs_subs_per_connection, max_minedtx_subs_per_connection, logger}) {
     super();
 
     this.block_monitor = new BlockMonitor({web3_rpc_endpoint, nodeos_rpc_endpoint, poll_interval, logger});
-    this.web_socket_handler = new WebSocketHandler({ws_listening_host, ws_listening_port, web3_rpc_endpoint, logger});
+    this.web_socket_handler = new WebSocketHandler({ws_listening_host, ws_listening_port, web3_rpc_endpoint, miner_rpc_endpoint, logger});
     this.max_logs_subs_per_connection = max_logs_subs_per_connection;
     this.max_minedtx_subs_per_connection = max_minedtx_subs_per_connection;
     this.web3 = new Web3(web3_rpc_endpoint);

--- a/peripherals/eos-evm-ws-proxy/websocket-handler.js
+++ b/peripherals/eos-evm-ws-proxy/websocket-handler.js
@@ -62,97 +62,85 @@ class WebSocketHandler extends EventEmitter {
     });
   }
   
-  async handle_eth_subscribe(ws, data) {
+  handle_eth_subscribe(ws, data) {
 
-    try {
-      if (!data.hasOwnProperty('params') || !Array.isArray(data.params) || data.params.length == 0) {
-        throw new Error("No params");
-      }
+    if (!data.hasOwnProperty('params') || !Array.isArray(data.params) || data.params.length == 0) {
+      throw new Error("No params");
+    }
 
-      const subscription_type = data.params[0];
-      if( subscription_type == "newHeads") {
-        const subid = uuidv4();
-        this.emit('newHeads', {subid, ws});
-        ws.send(JSON.stringify({ jsonrpc: "2.0", result: subid, id: data.id }));
-      } else if (subscription_type == "logs") {
-        const subid = uuidv4();
-        let filter = {};
-        if(data.params.length > 1) {
-          filter = data.params[1];
-          if (!(is_plain_object(filter) && filter != null)) {
-            throw new Error("Invalid filter");
-          }
-          if (filter.hasOwnProperty('address') && !(typeof filter.address === 'string' || Array.isArray(filter.address))) {
-            throw new Error("Invalid address filter");
-          }
-          if (filter.hasOwnProperty('topics') && !Array.isArray(filter.topics)) {
-            throw new Error("Invalid topics filter");
-          }
+    const subscription_type = data.params[0];
+    if( subscription_type == "newHeads") {
+      const subid = uuidv4();
+      this.emit('newHeads', {subid, ws});
+      return { jsonrpc: "2.0", result: subid, id: data.id };
+    } else if (subscription_type == "logs") {
+      const subid = uuidv4();
+      let filter = {};
+      if(data.params.length > 1) {
+        filter = data.params[1];
+        if (!(is_plain_object(filter) && filter != null)) {
+          throw new Error("Invalid filter");
         }
-        this.emit('logs', {subid, ws, filter});
-        ws.send(JSON.stringify({ jsonrpc: "2.0", result: subid, id: data.id }));
-      } else if (subscription_type == "minedTransactions") {
-        const subid = uuidv4();
-        let filter = {};
-        if(data.params.length > 1) {
-          filter = data.params[1];
-          if (!(is_plain_object(filter) && filter != null)) {
-            throw new Error("Invalid filter");
+        if (filter.hasOwnProperty('address') && !(typeof filter.address === 'string' || Array.isArray(filter.address))) {
+          throw new Error("Invalid address filter");
+        }
+        if (filter.hasOwnProperty('topics') && !Array.isArray(filter.topics)) {
+          throw new Error("Invalid topics filter");
+        }
+      }
+      this.emit('logs', {subid, ws, filter});
+      return { jsonrpc: "2.0", result: subid, id: data.id };
+    } else if (subscription_type == "minedTransactions") {
+      const subid = uuidv4();
+      let filter = {};
+      if(data.params.length > 1) {
+        filter = data.params[1];
+        if (!(is_plain_object(filter) && filter != null)) {
+          throw new Error("Invalid filter");
+        }
+        if (filter.hasOwnProperty('addresses')) {
+          if(!Array.isArray(filter.addresses)) {
+            throw new Error("Invalid addresses filter");
           }
-          if (filter.hasOwnProperty('addresses')) {
-            if(!Array.isArray(filter.addresses)) {
-              throw new Error("Invalid addresses filter");
+          for(const ofilter of filter.addresses) {
+            this.logger.debug("ELEMENT: ", ofilter);
+            if(!is_plain_object(ofilter) || (typeof(ofilter.to) != 'string' && typeof(ofilter.from) != 'string') ) {
+              throw new Error("Invalid addresses filter element");
             }
-            for(const ofilter of filter.addresses) {
-              this.logger.debug("ELEMENT: ", ofilter);
-              if(!is_plain_object(ofilter) || (typeof(ofilter.to) != 'string' && typeof(ofilter.from) != 'string') ) {
-                throw new Error("Invalid addresses filter element");
-              }
-              if(typeof(ofilter.to) == 'string') {
-                ofilter.to = ofilter.to.toLowerCase();
-              }
-              if(typeof(ofilter.from) == 'string') {
-                ofilter.from = ofilter.from.toLowerCase();
-              }
+            if(typeof(ofilter.to) == 'string') {
+              ofilter.to = ofilter.to.toLowerCase();
+            }
+            if(typeof(ofilter.from) == 'string') {
+              ofilter.from = ofilter.from.toLowerCase();
             }
           }
-          if (filter.hasOwnProperty('includeRemoved') && typeof(filter.includeRemoved) != 'boolean') {
-            throw new Error("Invalid includeRemoved filter");
-          }
-          if (filter.hasOwnProperty('hashesOnly') && typeof(filter.hashesOnly) != 'boolean') {
-            throw new Error("Invalid hashesOnly filter");
-          }
         }
-        this.emit('minedTransactions', {subid, ws, filter});
-        ws.send(JSON.stringify({ jsonrpc: "2.0", result: subid, id: data.id }));
-      } else {
-        throw new Error(`${data.params[0]} not supported`);
+        if (filter.hasOwnProperty('includeRemoved') && typeof(filter.includeRemoved) != 'boolean') {
+          throw new Error("Invalid includeRemoved filter");
+        }
+        if (filter.hasOwnProperty('hashesOnly') && typeof(filter.hashesOnly) != 'boolean') {
+          throw new Error("Invalid hashesOnly filter");
+        }
       }
-    } catch (error) {
-      this.send_json_rpc_error(ws, data.id, -32000, error.message);
+      this.emit('minedTransactions', {subid, ws, filter});
+      return { jsonrpc: "2.0", result: subid, id: data.id };
+    } else {
+      throw new Error(`${data.params[0]} not supported`);
     }
   }
  
-  async handle_eth_unsubscribe(ws, data) {
-    try {
-      if (!data.hasOwnProperty('params') || !Array.isArray(data.params) || data.params.length == 0) {
-        throw new Error("Invalid params");
-      }
-      const subid = data.params[0];
-      this.emit('unsubscribe', {subid, ws});
-      ws.send(JSON.stringify({ jsonrpc: "2.0", result: true, id: data.id }));
-    } catch (error) {
-      this.send_json_rpc_error(ws, data.id, -32000, error.message);
+  handle_eth_unsubscribe(ws, data) {
+    if (!data.hasOwnProperty('params') || !Array.isArray(data.params) || data.params.length == 0) {
+      throw new Error("Invalid params");
     }
+    const subid = data.params[0];
+    this.emit('unsubscribe', {subid, ws});
+    return { jsonrpc: "2.0", result: true, id: data.id };
   }
 
-  async handle_other_methods(ws, data) {
-    try {
-      const response = await axios.post(this.web3_rpc_endpoint, data);
-      ws.send(JSON.stringify(response.data));
-    } catch (error) {
-      this.send_json_rpc_error(ws, data.id, -32000, "Sever Error");
-    }
+  async handle_other_methods(data) {
+    const response = await axios.post(this.web3_rpc_endpoint, data);
+    return response.data;
   }
 
   send_json_rpc_error(ws, id, code, message) {
@@ -173,18 +161,98 @@ class WebSocketHandler extends EventEmitter {
         return;
     }
 
-    switch (data.method) {
+    if (Array.isArray(data)) {
+      let data2 = [];
+      for (let i = 0; i < data.length; ++i) {
+        switch(data[i].method) {
+          case 'eth_subscribe':
+            break;
+          case 'eth_unsubscribe':
+            break;
+          default:
+            data2.push(data[i]);
+        }
+      }
+      let rpc_response_data = [];
+      let rpc_error_message = null;
+      if (data2.length > 0) {
+        const rpc_response = await this.handle_other_methods(data2);
+        if (Array.isArray(rpc_response)) {
+          rpc_response_data = rpc_response;
+        } else {
+          rpc_error_message = "RPC Server Error:" + JSON.stringify({message: rpc_response});
+        }
+      }
+      let rpc_index = 0;
+      let batch_response = [];
+      for (let i = 0; i < data.length; ++i) {
+        switch(data[i].method) {
+          case 'eth_subscribe':
+            try {
+              batch_response.push(this.handle_eth_subscribe(ws, data[i]));
+            } catch (error) {
+              batch_response.push({ 
+                id      : data[i].id,
+                jsonrpc : "2.0",
+                error   : { code: -32000, message: error.message }
+              });
+            }
+            break;
+          case 'eth_unsubscribe':
+            try {
+              batch_response.push(this.handle_eth_unsubscribe(ws, data[i]));
+            } catch (error) {
+              batch_response.push({ 
+                id      : data[i].id,
+                jsonrpc : "2.0",
+                error   : { code: -32000, message: error.message }
+              });
+            }
+            break;
+          default:
+            if (rpc_index < rpc_response_data.length) {
+              batch_response.push(rpc_response_data[rpc_index]);
+              rpc_index++;
+            } else {
+              batch_response.push({ 
+                id      : data[i].id,
+                jsonrpc : "2.0",
+                error   : { code: -32000, message: rpc_error_message }
+              });
+            }
+        }
+      }
+      ws.send(JSON.stringify(batch_response));
+    }
+    else {
+      switch (data.method) {
         case 'eth_subscribe':
-          await this.handle_eth_subscribe(ws, data);
+          try {
+            const response_json = this.handle_eth_subscribe(ws, data);
+            ws.send(JSON.stringify(response_json));
+          } catch (error) {
+            this.send_json_rpc_error(ws, data.id, -32000, error.message);
+          }
           break;
 
         case 'eth_unsubscribe':
-          await this.handle_eth_unsubscribe(ws, data);  
+          try {
+            const response_json = this.handle_eth_unsubscribe(ws, data);  
+            ws.send(JSON.stringify(response_json));
+          } catch (error) {
+            this.send_json_rpc_error(ws, data.id, -32000, error.message);
+          }
           break;
 
         default:
-          await this.handle_other_methods(ws, data);
+          try {
+            const response_json = await this.handle_other_methods(data);
+            ws.send(JSON.stringify(response_json));
+          } catch (error) {
+            this.send_json_rpc_error(ws, data.id, -32000, "RPC Server Error:" + JSON.stringify({error: error}));
+          }
           break;
+      }
     }
 
   }

--- a/peripherals/eos-evm-ws-proxy/websocket-handler.js
+++ b/peripherals/eos-evm-ws-proxy/websocket-handler.js
@@ -28,14 +28,21 @@ const { is_plain_object } = require('./utils');
 
 class WebSocketHandler extends EventEmitter {
 
-  constructor({ ws_listening_host, ws_listening_port, web3_rpc_endpoint, miner_rpc_endpoint, logger }) {
+  constructor({ ws_listening_host, ws_listening_port, web3_rpc_endpoint, web3_rpc_test_endpoint, miner_rpc_endpoint, logger, whitelist_methods }) {
     super();
 
     this.host = ws_listening_host;
     this.port = ws_listening_port;
     this.web3_rpc_endpoint = web3_rpc_endpoint;
+    this.web3_rpc_test_endpoint = web3_rpc_test_endpoint;
     this.miner_rpc_endpoint = miner_rpc_endpoint;
     this.logger = logger;
+    this.whitelist_methods = whitelist_methods.split(",");
+
+    console.log("web3_rpc_endpoint is:", this.web3_rpc_endpoint);
+    console.log("web3_rpc_test_endpoint is:", this.web3_rpc_test_endpoint);
+    console.log("miner_rpc_endpoint is:", this.miner_rpc_endpoint);
+    console.log("whitelist_methods are:", this.whitelist_methods);
 
     this.server = http.createServer((req, res) => {
       this.handle_http_request(req, res);
@@ -144,9 +151,14 @@ class WebSocketHandler extends EventEmitter {
     return response.data;
   }
 
-  async handle_other_methods(data) {
-    const response = await axios.post(this.web3_rpc_endpoint, data);
-    return response.data;
+  async handle_other_methods(data, use_test_rpc) {
+    if (use_test_rpc) {
+      const response = await axios.post(this.web3_rpc_test_endpoint, data);
+      return response.data;
+    } else {
+      const response = await axios.post(this.web3_rpc_endpoint, data);
+      return response.data;
+    }
   }
 
   send_json_rpc_error(ws, id, code, message) {
@@ -160,6 +172,7 @@ class WebSocketHandler extends EventEmitter {
   async handle_message(ws, message) {
 
     let data;
+    let use_test_rpc = false;
     try {
         data = JSON.parse(message);
     } catch (e) {
@@ -177,6 +190,9 @@ class WebSocketHandler extends EventEmitter {
           case 'eth_sendRawTransaction':
             break;
           default:
+            if ((this.whitelist_methods.indexOf(data[i].method) < 0)) {
+              use_test_rpc = true;
+            }
             data2.push(data[i]);
         }
       }
@@ -184,7 +200,7 @@ class WebSocketHandler extends EventEmitter {
       let rpc_error_message = null;
       if (data2.length > 0) {
         try {
-          const rpc_response = await this.handle_other_methods(data2);
+          const rpc_response = await this.handle_other_methods(data2, use_test_rpc);
           if (Array.isArray(rpc_response)) {
             rpc_response_data = rpc_response;
           } else {
@@ -278,7 +294,10 @@ class WebSocketHandler extends EventEmitter {
           break;
         default:
           try {
-            const response_json = await this.handle_other_methods(data);
+            if ((this.whitelist_methods.indexOf(data.method) < 0)) {
+              use_test_rpc = true;
+            }
+            const response_json = await this.handle_other_methods(data, use_test_rpc);
             ws.send(JSON.stringify(response_json));
           } catch (error) {
             this.send_json_rpc_error(ws, data.id, -32000, "RPC Server Error:" + error.message);


### PR DESCRIPTION
Resolves #91 

add web3_rpc_test_endpoint in config
add miner_rpc_endpoint in config
add whitelist_methods in config
always group all requests in a batch to send to either rpc endpoint or rpc test endpoint.
reduce frequency of get eos lib
add minmum (180) size in this.reversible_blocks as protection in case of evm-rpc is out of sync with leap endpoint
