### PR TITLE
Prepare rate limit in nginx config files

### DIFF
--- a/peripherals/proxy/nginx.conf
+++ b/peripherals/proxy/nginx.conf
@@ -45,6 +45,7 @@ http {
   }
 
   limit_req_zone $http_x_forwarded_for zone=rate_limit_zone:10m rate=5r/s;
+  limit_conn_zone $http_x_forwarded_for zone=conn_limit_zone:10m;
 
   server {
     listen       80;
@@ -56,7 +57,9 @@ http {
       try_files /nonexistent @$http_upgrade;                             
     }                                                                                          
                                                                                                
-    location @websocket {                                                                      
+    location @websocket {           
+      limit_conn conn_limit_zone 2;
+      limit_conn_dry_run on;                                                           
       # websocket related stuff                                                                
       if ($request_method = 'OPTIONS') {                                                        
           add_header 'Access-Control-Allow-Origin' '*';                                        

--- a/peripherals/proxy/nginx.conf
+++ b/peripherals/proxy/nginx.conf
@@ -44,11 +44,15 @@ http {
      ~^5 1;
   }
 
+  limit_req_zone $http_x_forwarded_for zone=rate_limit_zone:10m rate=5r/s;
+
   server {
     listen       80;
     server_name  localhost;
 
-    location / {                                                                               
+    location / {                     
+      limit_req zone=rate_limit_zone burst=25 nodelay;
+      limit_req_dry_run on;                                                         
       try_files /nonexistent @$http_upgrade;                             
     }                                                                                          
                                                                                                


### PR DESCRIPTION
Solve #85 

Currently the limit is set to 5r/s burst 25 with dry run mode. 

We should run with dry run after upgraded to 0.7 and try to figure out a proper limit before we really apply the limit.