### PR TITLE
Process configchange event and save the parameters in some data structure.

### DIFF
--- a/src/block_conversion_plugin.cpp
+++ b/src/block_conversion_plugin.cpp
@@ -279,11 +279,11 @@ class block_conversion_plugin_impl : std::enable_shared_from_this<block_conversi
                   curr.consensus_parameters_cache.emplace(eosevm::ConsensusParameters {
                      .min_gas_price = std::visit([](auto&& arg) -> auto& { return arg.minimum_gas_price; }, new_config),
                      .gas_fee_parameters = eosevm::GasFeeParameters {
-                        .gas_txnewaccount = std::visit([](auto&& arg) -> auto& { return arg.gas_txnewaccount; }, new_config),
-                        .gas_newaccount = std::visit([](auto&& arg) -> auto& { return arg.gas_newaccount; }, new_config),
-                        .gas_txcreate = std::visit([](auto&& arg) -> auto& { return arg.gas_txcreate; }, new_config),
-                        .gas_codedeposit = std::visit([](auto&& arg) -> auto& { return arg.gas_codedeposit; }, new_config),
-                        .gas_sset = std::visit([](auto&& arg) -> auto& { return arg.gas_sset; }, new_config),
+                        .gas_txnewaccount = std::visit([](auto&& arg) -> auto& { return arg.gas_parameter.gas_txnewaccount; }, new_config),
+                        .gas_newaccount = std::visit([](auto&& arg) -> auto& { return arg.gas_parameter.gas_newaccount; }, new_config),
+                        .gas_txcreate = std::visit([](auto&& arg) -> auto& { return arg.gas_parameter.gas_txcreate; }, new_config),
+                        .gas_codedeposit = std::visit([](auto&& arg) -> auto& { return arg.gas_parameter.gas_codedeposit; }, new_config),
+                        .gas_sset = std::visit([](auto&& arg) -> auto& { return arg.gas_parameter.gas_sset; }, new_config),
                      }
                   });
                   curr.consensus_parameter_index = curr.header.number;
@@ -361,8 +361,8 @@ class block_conversion_plugin_impl : std::enable_shared_from_this<block_conversi
          return evmtx;
       }
 
-      inline gas_parameter_data_type deserialize_config(const channels::native_action& na) const {
-         gas_parameter_data_type new_configs;
+      inline consensus_parameter_data_type deserialize_config(const channels::native_action& na) const {
+         consensus_parameter_data_type new_configs;
          eosio::convert_from_bin(new_configs, na.data);
          return new_configs;
       }

--- a/src/block_conversion_plugin.cpp
+++ b/src/block_conversion_plugin.cpp
@@ -288,9 +288,9 @@ class block_conversion_plugin_impl : std::enable_shared_from_this<block_conversi
                         .gas_sset = std::visit([](auto&& arg) -> auto& { return arg.gas_parameter.gas_sset; }, new_config),
                      }
                   };
-                  curr.consensus_parameter_index = curr.header.number;
+                  curr.consensus_parameter_index = consensus_param.hash();
 
-                  silkworm::db::update_consensus_parameters(appbase::app().get_plugin<blockchain_plugin>().get_tx(), curr.header.number, consensus_param);
+                  silkworm::db::update_consensus_parameters(appbase::app().get_plugin<blockchain_plugin>().get_tx(), *curr.consensus_parameter_index, consensus_param);
                }
 
                for_each_action(*new_block, [this, &curr, &block_version](const auto& act){

--- a/src/block_conversion_plugin.hpp
+++ b/src/block_conversion_plugin.hpp
@@ -19,16 +19,21 @@ struct evmtx_v0 {
 using evmtx_type = std::variant<evmtx_v0>;
 EOSIO_REFLECT(evmtx_v0, eos_evm_version, rlpx)
 
-struct gas_parameter_data_v1 {
-    uint64_t minimum_gas_price = 0;
+struct gas_parameter_type {
     uint64_t gas_txnewaccount = 0;
     uint64_t gas_newaccount = 25000;
     uint64_t gas_txcreate = 32000;
     uint64_t gas_codedeposit = 200;
     uint64_t gas_sset = 20000;
 };
-using gas_parameter_data_type = std::variant<gas_parameter_data_v1>;
-EOSIO_REFLECT(gas_parameter_data_v1, minimum_gas_price, gas_txnewaccount, gas_newaccount, gas_txcreate, gas_codedeposit, gas_sset)
+EOSIO_REFLECT(gas_parameter_type, gas_txnewaccount, gas_newaccount, gas_txcreate, gas_codedeposit, gas_sset)
+
+struct consensus_parameter_data_v0 {
+    uint64_t                   minimum_gas_price = 0;
+    gas_parameter_type         gas_parameter;
+};
+using consensus_parameter_data_type = std::variant<consensus_parameter_data_v0>;
+EOSIO_REFLECT(consensus_parameter_data_v0, minimum_gas_price, gas_parameter)
 
 class block_conversion_plugin : public appbase::plugin<block_conversion_plugin> {
    public:

--- a/src/block_conversion_plugin.hpp
+++ b/src/block_conversion_plugin.hpp
@@ -19,6 +19,17 @@ struct evmtx_v0 {
 using evmtx_type = std::variant<evmtx_v0>;
 EOSIO_REFLECT(evmtx_v0, eos_evm_version, rlpx)
 
+struct gas_parameter_data_v1 {
+    uint64_t minimum_gas_price = 0;
+    uint64_t gas_txnewaccount = 0;
+    uint64_t gas_newaccount = 25000;
+    uint64_t gas_txcreate = 32000;
+    uint64_t gas_codedeposit = 200;
+    uint64_t gas_sset = 20000;
+};
+using gas_parameter_data_type = std::variant<gas_parameter_data_v1>;
+EOSIO_REFLECT(gas_parameter_data_v1, minimum_gas_price, gas_txnewaccount, gas_newaccount, gas_txcreate, gas_codedeposit, gas_sset)
+
 class block_conversion_plugin : public appbase::plugin<block_conversion_plugin> {
    public:
       APPBASE_PLUGIN_REQUIRES((sys_plugin)(ship_receiver_plugin)(engine_plugin));

--- a/src/blockchain_plugin.cpp
+++ b/src/blockchain_plugin.cpp
@@ -47,24 +47,43 @@ class blockchain_plugin_impl : std::enable_shared_from_this<blockchain_plugin_im
                      exec_engine->open();
                   }
 
-                  exec_engine->insert_block(new_block);
-                  if(!(++block_count % 5000) || !new_block->irreversible) {
-                     // Get the last complete EVM block from irreversible EOS blocks.
-                     // The height is uint64_t so we can get it as a whole without worrying about atomicity.
-                     // Even some data races happen, it's fine in our scenario to read old data as starting from earlier blocks is always safer.
-                     uint64_t evm_lib = appbase::app().get_plugin<block_conversion_plugin>().get_evm_lib();
-                     SILK_INFO << "Storing EVM Lib: " << "#" << evm_lib;
+                  if (new_block->consensus_parameter_index && *new_block->consensus_parameter_index == new_block->header.number) {
+                     // New configs coming in.
+                     // 1. Save the new parameters.
+                     update_consensus_parameters(exec_engine->get_tx(), new_block->header.number, *new_block->consensus_parameters_cache);
 
-                     // Storing the EVM block height of the last complete block from irreversible EOS blocks.
-                     // We have to do this in this thread with the tx instance stored in exec_engine due to the lmitation of MDBX.
-                     // Note there's no need to commit here as the tx is borrowed. ExecutionEngine will manange the commits.
-                     // There's some other advantage to save this height in this way: 
-                     // If the system is shut down during catching up irreversible blocks, i.e. in the middle of the 5000 block run,
-                     // saving the height in this way can minimize the possibility having a stored height that is higher than the canonical header.
-                     write_runtime_states_u64(exec_engine->get_tx(), evm_lib, silkworm::db::RuntimeState::kLibProcessed);
+                     // 2. Process all pending blocks with old parameters, this shall commit the new parameters together.
+                     exec_engine->verify_chain(new_block->header.parent_hash);
 
+                     // 3. insert new block, even we need the new parameters during the process (should not),
+                     //  we should have it in db and memory.
+                     exec_engine->insert_block(new_block);
+
+                     // 4. Proccess block immediatly so we could fail at once were there be any problems.
+                     // Maybe not necessary and can merge this to the code below.
                      exec_engine->verify_chain(new_block->header.hash());
                      block_count=0;
+                  }
+                  else {
+                     exec_engine->insert_block(new_block);
+                     if(!(++block_count % 5000) || !new_block->irreversible) {
+                        // Get the last complete EVM block from irreversible EOS blocks.
+                        // The height is uint64_t so we can get it as a whole without worrying about atomicity.
+                        // Even some data races happen, it's fine in our scenario to read old data as starting from earlier blocks is always safer.
+                        uint64_t evm_lib = appbase::app().get_plugin<block_conversion_plugin>().get_evm_lib();
+                        SILK_INFO << "Storing EVM Lib: " << "#" << evm_lib;
+
+                        // Storing the EVM block height of the last complete block from irreversible EOS blocks.
+                        // We have to do this in this thread with the tx instance stored in exec_engine due to the lmitation of MDBX.
+                        // Note there's no need to commit here as the tx is borrowed. ExecutionEngine will manange the commits.
+                        // There's some other advantage to save this height in this way: 
+                        // If the system is shut down during catching up irreversible blocks, i.e. in the middle of the 5000 block run,
+                        // saving the height in this way can minimize the possibility having a stored height that is higher than the canonical header.
+                        write_runtime_states_u64(exec_engine->get_tx(), evm_lib, silkworm::db::RuntimeState::kLibProcessed);
+
+                        exec_engine->verify_chain(new_block->header.hash());
+                        block_count=0;
+                     }
                   }
                } catch (const mdbx::exception& ex) {
                   sys::error("evm_blocks_subscription: mdbx::exception, " + std::string(ex.what()));

--- a/src/blockchain_plugin.cpp
+++ b/src/blockchain_plugin.cpp
@@ -47,9 +47,33 @@ class blockchain_plugin_impl : std::enable_shared_from_this<blockchain_plugin_im
                      exec_engine->open();
                   }
 
-                  if (new_block->consensus_parameter_index && *new_block->consensus_parameter_index == new_block->header.number) {
-                     SILKWORM_ASSERT(new_block->consensus_parameters_cache.has_value());
-                     update_consensus_parameters(exec_engine->get_tx(), new_block->header.number, *new_block->consensus_parameters_cache);
+                  if (new_block->consensus_parameter_index) {
+                     if (*new_block->consensus_parameter_index == new_block->header.number) {
+                        // Parameters updated in this block.
+                        SILKWORM_ASSERT(new_block->consensus_parameters_cache.has_value());
+                        update_consensus_parameters(exec_engine->get_tx(), new_block->header.number, *new_block->consensus_parameters_cache);
+                        last_consensus_parameters = new_block->consensus_parameters_cache;
+                        last_consensus_parameters_index = new_block->consensus_parameter_index;
+                     }
+                     else if (last_consensus_parameters_index && *last_consensus_parameters_index == *new_block->consensus_parameter_index) {
+                        // Copy over parameters for last block.
+                        SILKWORM_ASSERT(last_consensus_parameters.has_value());
+                        new_block->consensus_parameters_cache = last_consensus_parameters;
+                     } else {
+                        // Parameter not cached, happen during startup or fork.
+                        new_block->consensus_parameters_cache = read_consensus_parameters(exec_engine->get_tx(), *new_block->consensus_parameter_index);
+                        // In such cases, the parameter MUST be in db.
+                        SILKWORM_ASSERT(new_block->consensus_parameters_cache.has_value());
+
+                        last_consensus_parameters_index = new_block->consensus_parameter_index;
+                        last_consensus_parameters = new_block->consensus_parameters_cache;
+                     }  
+                  }
+                  else {
+                     // Should only reach here if fork happens during version update.
+                     // TODO: Add guards according to eosevm versions.
+                     last_consensus_parameters_index = std::nullopt;
+                     last_consensus_parameters = std::nullopt;
                   }
                   
                   exec_engine->insert_block(new_block);
@@ -93,6 +117,8 @@ class blockchain_plugin_impl : std::enable_shared_from_this<blockchain_plugin_im
       mdbx::env*                                              db_env;
       channels::evm_blocks::channel_type::handle              evm_blocks_subscription;
       std::unique_ptr<ExecutionEngineEx>  exec_engine;
+      std::optional<silkworm::BlockNum>                       last_consensus_parameters_index;
+      std::optional<eosevm::ConsensusParameters>              last_consensus_parameters;
 };
 
 blockchain_plugin::blockchain_plugin() : my(new blockchain_plugin_impl()) {}

--- a/src/channels.hpp
+++ b/src/channels.hpp
@@ -41,15 +41,6 @@ namespace channels {
       std::optional<native_action>  new_config = std::nullopt;
       std::vector<native_trx> transactions;
    };
-
-   struct consensus_parameter_event {
-      intx::uint256 min_gas_fee = 0;
-      uint64_t gas_txnewaccount = 0;
-      uint64_t gas_newaccount = 0;
-      uint64_t gas_txcreate = 0;
-      uint64_t gas_codedeposit = 0;
-      uint64_t gas_sset = 0;
-   };
    
    using native_blocks = appbase::channel_decl<struct native_blocks_tag, std::shared_ptr<native_block>>;
    using evm_blocks = appbase::channel_decl<struct evm_blocks_tag, std::shared_ptr<silkworm::Block>>;

--- a/src/channels.hpp
+++ b/src/channels.hpp
@@ -38,7 +38,17 @@ namespace channels {
       uint32_t                block_num = 0;
       int64_t                 timestamp = 0;
       uint32_t                lib = 0;
+      std::optional<native_action>  new_config = std::nullopt;
       std::vector<native_trx> transactions;
+   };
+
+   struct consensus_parameter_event {
+      intx::uint256 min_gas_fee = 0;
+      uint64_t gas_txnewaccount = 0;
+      uint64_t gas_newaccount = 0;
+      uint64_t gas_txcreate = 0;
+      uint64_t gas_codedeposit = 0;
+      uint64_t gas_sset = 0;
    };
    
    using native_blocks = appbase::channel_decl<struct native_blocks_tag, std::shared_ptr<native_block>>;

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -5,6 +5,7 @@
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/infra/common/log.hpp>
 
+static constexpr eosio::name configchange_n = eosio::name("configchange");
 static constexpr eosio::name pushtx_n = eosio::name("pushtx");
 static constexpr eosio::name evmtx_n = eosio::name("evmtx");
 


### PR DESCRIPTION
Resolve #186 

The planned implementation is like this:

1 ship_receiver_plugin will check if it received a configchange event, if found, make sure it's the first related action in a block, save the new config in the resulting native_block/

2 block_conversion_plugin will make sure if there's a new config in the incoming native_block, it should be the first one native block for a resulting evm block. Then: 
a save the new config in the resulting evm block
b change the evm block's consensus_parameter_index to it's own height.

3 blockchain_plugin will detect if there's new config coming in with the evm blocks. if so:
a save new parameters
b verify_chain for the blocks before if necessary

c insert the incoming blcok
d verify chain (may be not necessary)

-- EDIT: after some double thinking, we do not need this for blockchain_plugin, let's just try a normal process first.

