### PR TITLE
[1.0.2] Update versions/branches to use for CI dependencies

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,10 +1,10 @@
 {
    "antelope-spring-dev":{
-      "target":"main",
+      "target":"1",
       "prerelease":false
    },
    "cdt":{
-      "target":"3.1.0",
+      "target":"4",
       "prerelease":false
    },
    "eos-evm-contract":{
@@ -12,6 +12,7 @@
       "prerelease":false
    },
    "eos-evm-miner":{
-      "target":"main"
+      "target":"release/1.0",
+      "prerelease":false
    }
 }


### PR DESCRIPTION
For EOS EVM Node v1.x integration tests, we should use the latest stable versions of Spring (1.x) and CDT (4.x) rather than the versions in the respective repo's `main` branch. Also, the latest stable 1.x version of EOS EVM Miner should be used.