### PR TITLE
[1.0.2 -> main] Update versions/branches to use for CI dependencies

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -12,7 +12,7 @@
       "prerelease":false
    },
    "eos-evm-miner":{
-      "target":"release/1.0",
+      "target":"main",
       "prerelease":false
    }
 }


### PR DESCRIPTION
Forwards #299 to `main` branch.

This means we continue using the latest stable versions of Spring (1.x) and CDT (4.x) rather than the versions in the respective repo's `main` branch. Unless we have a good reason to use the latest head of Spring development for our EOS EVM Node integration tests, it is a better idea to stick with a stable version.

However, we do want to use the `main` branch for the EOS EVM Contract and EOS EVM Miner dependencies.