### PR TITLE
[1.0] Allow batch eth_gasPrice

### DIFF
--- a/peripherals/proxy/eth-jsonrpc-access.lua
+++ b/peripherals/proxy/eth-jsonrpc-access.lua
@@ -78,7 +78,7 @@ if empty(method) or empty(version) then
       return
     end
     if write_calls ~= nil then                               
-      if contains(write_calls, v['method']) then                  
+      if contains(write_calls, v['method']) and v['method'] ~= 'eth_gasPrice' then
         ngx.log(ngx.ERR, 'batch write calls not allowed') 
         ngx.exit(ngx.HTTP_BAD_REQUEST)     
         return   


### PR DESCRIPTION
Resolve #339 

1 We open the API in silkworm
2 We make sure the batches containing 'eth_gasPrice' is properly forwarded.