### PR TITLE
[1.0] Encode transaction properly in the tx removal step during fork

### DIFF
--- a/src/block_conversion_plugin.cpp
+++ b/src/block_conversion_plugin.cpp
@@ -230,7 +230,7 @@ class block_conversion_plugin_impl : std::enable_shared_from_this<block_conversi
                               auto txid_a = ethash::keccak256(rlpx_ref.data(), rlpx_ref.size());
 
                               silkworm::Bytes transaction_rlp{};
-                              silkworm::rlp::encode(transaction_rlp, evm_blocks.back().transactions.back());
+                              silkworm::rlp::encode(transaction_rlp, evm_blocks.back().transactions.back(), /* wrap_eip2718_into_string */ false);
                               auto txid_b = ethash::keccak256(transaction_rlp.data(), transaction_rlp.size());
 
                               // Ensure that the transaction to be removed is the correct one


### PR DESCRIPTION
For #344 

The problem only happens when the second EOS block of an EVM block is forked. 

The current test framework seems to have some difficulty to accurately emulate this case.

Maybe we should fix the issue first and slit the unit test to a separate issue so that we can have it fixed asap?