### PR TITLE
[1.0->main] Encode transaction properly in the tx removal step during fork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include(cmake/conan.cmake)
 
 set(VERSION_MAJOR 1)
 set(VERSION_MINOR 0)
-set(VERSION_PATCH 6)
+set(VERSION_PATCH 7)
 #set(VERSION_SUFFIX rc4)
 
 if(VERSION_SUFFIX)

--- a/src/block_conversion_plugin.cpp
+++ b/src/block_conversion_plugin.cpp
@@ -239,7 +239,7 @@ class block_conversion_plugin_impl : std::enable_shared_from_this<block_conversi
                               auto txid_a = ethash::keccak256(rlpx_ref.data(), rlpx_ref.size());
 
                               silkworm::Bytes transaction_rlp{};
-                              silkworm::rlp::encode(transaction_rlp, evm_blocks.back().transactions.back());
+                              silkworm::rlp::encode(transaction_rlp, evm_blocks.back().transactions.back(), /* wrap_eip2718_into_string */ false);
                               auto txid_b = ethash::keccak256(transaction_rlp.data(), transaction_rlp.size());
 
                               // Ensure that the transaction to be removed is the correct one


### PR DESCRIPTION
Resolves #344 